### PR TITLE
Fix issue with ColorInput throwing warning

### DIFF
--- a/src/Components/ColorInput/ColorInput.jsx
+++ b/src/Components/ColorInput/ColorInput.jsx
@@ -30,7 +30,6 @@ export default function ColorInput({ currentColor }) {
           placeholder="#54c73d"
           value={hexValue}
           onChange={handleHexChange}
-          defaultValue={hexValue}
         ></input>
         <input
           id="color-hex--input"
@@ -51,7 +50,6 @@ export default function ColorInput({ currentColor }) {
           placeholder="#54c73d"
           value={contrastColorValue}
           onChange={handleContrastColorChange}
-          defaultValue={contrastColorValue}
         ></input>
         <input
           id="color-contrast-text--input"


### PR DESCRIPTION
This pull request is result of a bug fix on ColorInput.
ColorInput threw a warning because there were two props containing a string value:
1. value
2. defaultValue

To solve the issue, I needed to:
- consult the react docs and to learn more about controlled and uncontrolled inputs
- test if 1. or 2. could be taken out
- remove 2. (defaultValue) from the JSX input to solve the issue and thus clean the code