### PR TITLE
Refactor 22 color form

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -26,8 +26,8 @@ function App() {
   function handleEditTheme(newName) {
     setThemes((prevThemes) =>
       prevThemes.map((theme) =>
-        theme.id === selectedThemeId ? { ...theme, name: newName } : theme
-      )
+        theme.id === selectedThemeId ? { ...theme, name: newName } : theme,
+      ),
     );
   }
 
@@ -37,10 +37,10 @@ function App() {
         theme.id === selectedTheme.id
           ? {
               ...theme,
-              colors: [{ id: uid(), ...newColor }, ...theme.colors],
+              colors: [...theme.colors, { id: uid(), ...newColor }],
             }
-          : theme
-      )
+          : theme,
+      ),
     );
   }
 
@@ -52,8 +52,8 @@ function App() {
               ...theme,
               colors: theme.colors.filter((color) => color.id !== id),
             }
-          : theme
-      )
+          : theme,
+      ),
     );
   }
 
@@ -67,8 +67,8 @@ function App() {
                 return color.id === editedColor.id ? editedColor : color;
               }),
             }
-          : theme
-      )
+          : theme,
+      ),
     );
   }
 
@@ -86,8 +86,6 @@ function App() {
       />
 
       <h2>{selectedTheme.name}</h2>
-
-      <ColorForm onAddColor={handleAddColor} />
 
       {selectedTheme.colors.length === 0 && (
         <h3 className="no-colors-message">
@@ -109,6 +107,8 @@ function App() {
           );
         })}
       </ul>
+
+      <ColorForm onAddColor={handleAddColor} />
     </main>
   );
 }

--- a/src/Components/ColorCard/Color.css
+++ b/src/Components/ColorCard/Color.css
@@ -1,21 +1,28 @@
 .color-card {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  border-radius: 15px;
-  border: 1px solid black;
-  margin: 5px;
-  padding: 5px;
-  max-width: 500px;
-  min-height: 175px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    border-radius: 15px;
+    border: 1px solid black;
+    margin: 5px;
+    padding: 5px;
+    max-width: 500px;
+    min-height: 175px;
 }
 
 .color-card-headline {
-  font-size: 1.5rem;
-  border-radius: 10px;
+    font-size: 1.5rem;
+    border-radius: 10px;
+}
+
+.color-card-descriptor-label {
+    font-weight: 400;
+    font-size: 12;
+    margin-right: 5px;
+    padding: 2.5px;
 }
 
 .color-card--buttons {
-  display: flex;
-  gap: 0.5rem;
+    display: flex;
+    gap: 0.5rem;
 }

--- a/src/Components/ColorCard/ColorCard.jsx
+++ b/src/Components/ColorCard/ColorCard.jsx
@@ -14,7 +14,7 @@ export default function ColorCard({ color, onDeleteColor, onEditColor }) {
   }
 
   return (
-    <div
+    <section
       className="color-card"
       style={{
         background: color.hex,
@@ -22,7 +22,7 @@ export default function ColorCard({ color, onDeleteColor, onEditColor }) {
       }}
     >
       {editMode ? (
-        <div>
+        <>
           <ColorForm
             isEdit={true}
             initialData={color}
@@ -33,7 +33,7 @@ export default function ColorCard({ color, onDeleteColor, onEditColor }) {
             // }}
           />
           <Button buttonType="cancel" onClick={() => setEditMode(false)} />
-        </div>
+        </>
       ) : (
         <>
           <div>
@@ -54,6 +54,6 @@ export default function ColorCard({ color, onDeleteColor, onEditColor }) {
           </div>
         </>
       )}
-    </div>
+    </section>
   );
 }

--- a/src/Components/ColorCard/ColorCard.jsx
+++ b/src/Components/ColorCard/ColorCard.jsx
@@ -27,6 +27,10 @@ export default function ColorCard({ color, onDeleteColor, onEditColor }) {
             isEdit={true}
             initialData={color}
             onEditColor={handleEditColorConfirm}
+            // style={{
+            //   background: color.hex,
+            //   color: color.contrastText,
+            // }}
           />
           <Button buttonType="cancel" onClick={() => setEditMode(false)} />
         </div>

--- a/src/Components/ColorCard/ColorCard.jsx
+++ b/src/Components/ColorCard/ColorCard.jsx
@@ -38,9 +38,14 @@ export default function ColorCard({ color, onDeleteColor, onEditColor }) {
         <>
           <div>
             <h3 className="color-card-headline">{color.hex}</h3>
-
-            <h4>{color.role}</h4>
-            <p>Contrast Text {color.contrastText}</p>
+            <h4>
+              <span className="color-card-descriptor-label">Contrast Text</span>
+              {color.contrastText}
+            </h4>
+            <h4>
+              <span className="color-card-descriptor-label">Role</span>
+              {color.role}
+            </h4>
             <ContrastChecker color={color} />
           </div>
           <div className="color-card--buttons">

--- a/src/Components/ColorForm/ColorForm.css
+++ b/src/Components/ColorForm/ColorForm.css
@@ -1,46 +1,62 @@
 .color-form--form {
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  gap: 5px;
-  padding: 5px;
-  max-width: 500px;
-  min-height: 175px;
-  border: 1px black solid;
-  border-radius: 5px;
-  margin: 5px;
-  font-size: 14px;
+    display: flex;
+    justify-content: space-between;
+    max-width: 500px;
+    min-height: 175px;
+    border-radius: 5px;
+    margin: 5px;
+    // font-size: 14px;
 }
 
 .color-form--fieldset {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  gap: 10px;
-  min-width: 85%;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    gap: 10px;
+    min-width: 85%;
+    border: none;
 }
 
 /* this aligns the label and input of role due to diffrences in JSX structure compared to ColorInput */
 .color-form--role-label {
-  display: flex;
-  align-items: center;
-  gap: 5px;
+    display: flex;
+    align-items: center;
+    gap: 5px;
 }
 
 .color-form--color-input-wrapper {
-  display: flex;
-  gap: 5px;
-  border: 1px solid green;
+    display: flex;
+    gap: 5px;
 }
 
 .color-form--input-field--color-text {
-  flex-grow: 1;
+    flex-grow: 1;
+    border: none;
+    border-bottom: 1px solid black;
+    max-width: 150px;
+    border-radius: 5px;
 }
 
 .color-form--input-field--color-picker {
-  max-width: 34px;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+    max-width: 24px;
+    max-height: 24px;
+    padding: 0;
+    background-color: transparent;
+    cursor: pointer;
+    border: none;
+}
+
+.color-form--input-field--color-picker::-webkit-color-swatch {
+    border-radius: 5px;
+}
+
+.color-form--input-field--color-picker::-moz-color-swatch {
+    border-radius: 5px;
 }
 
 .color-form--submit-button:hover {
-  background-color: #6d98e7;
+    background-color: #6d98e7;
 }

--- a/src/Components/ColorForm/ColorForm.css
+++ b/src/Components/ColorForm/ColorForm.css
@@ -1,11 +1,10 @@
 .color-form--form {
     display: flex;
-    justify-content: space-between;
     max-width: 500px;
-    min-height: 175px;
+    max-height: 175px;
     border-radius: 5px;
     margin: 5px;
-    // font-size: 14px;
+    border-radius: 15px;
 }
 
 .color-form--fieldset {
@@ -17,24 +16,18 @@
     border: none;
 }
 
-/* this aligns the label and input of role due to diffrences in JSX structure compared to ColorInput */
-.color-form--role-label {
+.color-form--input-field {
     display: flex;
     align-items: center;
     gap: 5px;
 }
 
-.color-form--color-input-wrapper {
-    display: flex;
-    gap: 5px;
-}
-
 .color-form--input-field--color-text {
-    flex-grow: 1;
     border: none;
-    border-bottom: 1px solid black;
     max-width: 150px;
     border-radius: 5px;
+    border-bottom: 1px solid black;
+    background-color: rgba(255, 255, 255, 0.75);
 }
 
 .color-form--input-field--color-picker {
@@ -47,14 +40,17 @@
     background-color: transparent;
     cursor: pointer;
     border: none;
+    margin-left: 5px;
 }
 
 .color-form--input-field--color-picker::-webkit-color-swatch {
     border-radius: 5px;
+    border: 1px solid whitesmoke;
 }
 
 .color-form--input-field--color-picker::-moz-color-swatch {
     border-radius: 5px;
+    border: 1px solid white;
 }
 
 .color-form--submit-button:hover {

--- a/src/Components/ColorForm/ColorForm.css
+++ b/src/Components/ColorForm/ColorForm.css
@@ -1,40 +1,44 @@
 .color-form--form {
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
+  justify-content: space-between;
   gap: 5px;
   padding: 5px;
-  max-width: 350px;
-  
+  max-width: 500px;
+  min-height: 175px;
+  border: 1px black solid;
+  border-radius: 5px;
+  margin: 5px;
+  font-size: 14px;
+}
+
+.color-form--fieldset {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 10px;
+  min-width: 85%;
 }
 
 /* this aligns the label and input of role due to diffrences in JSX structure compared to ColorInput */
 .color-form--role-label {
   display: flex;
-  flex-direction: column;
+  align-items: center;
+  gap: 5px;
 }
 
 .color-form--color-input-wrapper {
   display: flex;
   gap: 5px;
+  border: 1px solid green;
 }
 
 .color-form--input-field--color-text {
-    flex-grow: 1;
+  flex-grow: 1;
 }
-
 
 .color-form--input-field--color-picker {
   max-width: 34px;
-}
-
-
-.color-form--submit-button {
-  /* border: 1.5px solid rgb(249, 147, 58); */
-  border-radius: 5px;
-  color: white;
-  font-weight: 800;
-  background-color: #346dda;
-  width: 100%;
 }
 
 .color-form--submit-button:hover {

--- a/src/Components/ColorForm/ColorForm.jsx
+++ b/src/Components/ColorForm/ColorForm.jsx
@@ -7,7 +7,7 @@ export default function ColorForm({
   isEdit,
   onAddColor,
   onEditColor,
-  initialData = { role: "some color", hex: "#b55b16", contrastText: "#ffffff" },
+  initialData = { role: "highlight", hex: "#b55b16", contrastText: "#ffffff" },
 }) {
   const [cardBackgroundColor, setCardBackgroundColor] = useState(
     initialData.hex,

--- a/src/Components/ColorForm/ColorForm.jsx
+++ b/src/Components/ColorForm/ColorForm.jsx
@@ -1,6 +1,7 @@
 import "./ColorForm.css";
 import ColorInput from "../ColorInput/ColorInput";
 import Button from "../Button/Button";
+import { useState } from "react";
 
 export default function ColorForm({
   isEdit,
@@ -8,6 +9,10 @@ export default function ColorForm({
   onEditColor,
   initialData = { role: "some color", hex: "#ffef22", contrastText: "#ffffff" },
 }) {
+  const [cardBackgroundColor, setCardBackgroundColor] = useState(
+    initialData.hex
+  );
+
   function handleSubmit(event) {
     event.preventDefault();
     const formData = new FormData(event.target);
@@ -19,12 +24,25 @@ export default function ColorForm({
     event.target.elements.role.focus();
   }
 
+  // function cardBcgSetter(hex) {
+  //   setCardBackgroundColor(hex);
+  // }
+
   return (
-    <form className="color-form--form" onSubmit={handleSubmit}>
+    <form
+      className="color-form--form"
+      onSubmit={handleSubmit}
+      style={{ backgroundColor: cardBackgroundColor }}
+      // style={{ backgroundColor: cardBackgroundColor.hex }}
+    >
       <fieldset className="color-form--fieldset">
         <label htmlFor="hex" className="color-form--role-label">
           Hex
-          <ColorInput id="hex" defaultValue={initialData.hex} />
+          <ColorInput
+            id="hex"
+            defaultValue={initialData.hex}
+            cardBackgroundColor={setCardBackgroundColor}
+          />
         </label>
 
         <label htmlFor="role" className="color-form--role-label">

--- a/src/Components/ColorForm/ColorForm.jsx
+++ b/src/Components/ColorForm/ColorForm.jsx
@@ -34,6 +34,7 @@ export default function ColorForm({
             name="role"
             type="text"
             defaultValue={initialData.role}
+            className="color-form--input-field--color-text"
           />
         </label>
 

--- a/src/Components/ColorForm/ColorForm.jsx
+++ b/src/Components/ColorForm/ColorForm.jsx
@@ -21,26 +21,30 @@ export default function ColorForm({
 
   return (
     <form className="color-form--form" onSubmit={handleSubmit}>
-      <label htmlFor="role" className="color-form--role-label">
-        Role
-        <input
-          id="role"
-          name="role"
-          type="text"
-          defaultValue={initialData.role}
-        />
-      </label>
+      <fieldset className="color-form--fieldset">
+        <label htmlFor="hex" className="color-form--role-label">
+          Hex
+          <ColorInput id="hex" defaultValue={initialData.hex} />
+        </label>
 
-      <label htmlFor="hex">
-        Hex
-        <ColorInput id="hex" defaultValue={initialData.hex} />
-      </label>
+        <label htmlFor="role" className="color-form--role-label">
+          Role
+          <input
+            id="role"
+            name="role"
+            type="text"
+            defaultValue={initialData.role}
+          />
+        </label>
 
-      <label htmlFor="contrastText">
-        Contrast Text
-        <ColorInput id="contrastText" defaultValue={initialData.contrastText} />
-      </label>
-
+        <label htmlFor="contrastText" className="color-form--role-label">
+          Contrast Text
+          <ColorInput
+            id="contrastText"
+            defaultValue={initialData.contrastText}
+          />
+        </label>
+      </fieldset>
       <Button
         buttonType={isEdit ? "edit" : "add"}
         type="submit"

--- a/src/Components/ColorForm/ColorForm.jsx
+++ b/src/Components/ColorForm/ColorForm.jsx
@@ -7,10 +7,13 @@ export default function ColorForm({
   isEdit,
   onAddColor,
   onEditColor,
-  initialData = { role: "some color", hex: "#ffef22", contrastText: "#ffffff" },
+  initialData = { role: "some color", hex: "#b55b16", contrastText: "#ffffff" },
 }) {
   const [cardBackgroundColor, setCardBackgroundColor] = useState(
     initialData.hex
+  );
+  const [cardContrastTextColor, setCardContrastTextColor] = useState(
+    initialData.contrastText
   );
 
   function handleSubmit(event) {
@@ -24,16 +27,14 @@ export default function ColorForm({
     event.target.elements.role.focus();
   }
 
-  // function cardBcgSetter(hex) {
-  //   setCardBackgroundColor(hex);
-  // }
-
   return (
     <form
       className="color-form--form"
       onSubmit={handleSubmit}
-      style={{ backgroundColor: cardBackgroundColor }}
-      // style={{ backgroundColor: cardBackgroundColor.hex }}
+      style={{
+        backgroundColor: cardBackgroundColor,
+        color: cardContrastTextColor,
+      }}
     >
       <fieldset className="color-form--fieldset">
         <label htmlFor="hex" className="color-form--role-label">
@@ -61,6 +62,7 @@ export default function ColorForm({
           <ColorInput
             id="contrastText"
             defaultValue={initialData.contrastText}
+            cardContrastTextColor={setCardContrastTextColor}
           />
         </label>
       </fieldset>

--- a/src/Components/ColorForm/ColorForm.jsx
+++ b/src/Components/ColorForm/ColorForm.jsx
@@ -10,10 +10,10 @@ export default function ColorForm({
   initialData = { role: "some color", hex: "#b55b16", contrastText: "#ffffff" },
 }) {
   const [cardBackgroundColor, setCardBackgroundColor] = useState(
-    initialData.hex
+    initialData.hex,
   );
   const [cardContrastTextColor, setCardContrastTextColor] = useState(
-    initialData.contrastText
+    initialData.contrastText,
   );
 
   function handleSubmit(event) {
@@ -37,7 +37,7 @@ export default function ColorForm({
       }}
     >
       <fieldset className="color-form--fieldset">
-        <label htmlFor="hex" className="color-form--role-label">
+        <label htmlFor="hex" className="color-form--input-field">
           Hex
           <ColorInput
             id="hex"
@@ -46,7 +46,16 @@ export default function ColorForm({
           />
         </label>
 
-        <label htmlFor="role" className="color-form--role-label">
+        <label htmlFor="contrastText" className="color-form--input-field">
+          Text
+          <ColorInput
+            id="contrastText"
+            defaultValue={initialData.contrastText}
+            cardContrastTextColor={setCardContrastTextColor}
+          />
+        </label>
+
+        <label htmlFor="role" className="color-form--input-field">
           Role
           <input
             id="role"
@@ -54,15 +63,6 @@ export default function ColorForm({
             type="text"
             defaultValue={initialData.role}
             className="color-form--input-field--color-text"
-          />
-        </label>
-
-        <label htmlFor="contrastText" className="color-form--role-label">
-          Contrast Text
-          <ColorInput
-            id="contrastText"
-            defaultValue={initialData.contrastText}
-            cardContrastTextColor={setCardContrastTextColor}
           />
         </label>
       </fieldset>

--- a/src/Components/ColorInput/ColorInput.jsx
+++ b/src/Components/ColorInput/ColorInput.jsx
@@ -16,7 +16,7 @@ export default function ColorInput({
   };
 
   return (
-    <div className="color-form--color-input-wrapper">
+    <>
       <input
         id={id}
         name={id}
@@ -31,6 +31,6 @@ export default function ColorInput({
         onChange={handleInputValue}
         className="color-form--input-field--color-picker"
       />
-    </div>
+    </>
   );
 }

--- a/src/Components/ColorInput/ColorInput.jsx
+++ b/src/Components/ColorInput/ColorInput.jsx
@@ -2,28 +2,27 @@ import { useState } from "react";
 
 export default function ColorInput({ id, defaultValue }) {
   const [inputValue, setInputValue] = useState(defaultValue);
- 
 
   const handleInputValue = (event) => {
     setInputValue(event.target.value);
   };
 
   return (
-    <div className="color-form--color-input-wrapper">    
-        <input
-          id={id}
-          name={id}
-          type="text"
-          value={inputValue}
-          onChange={handleInputValue}
-          className="color-form--input-field--color-text"
-        />
-        <input
-          type="color"
-          value={inputValue}
-          onChange={handleInputValue}
-          className="color-form--input-field--color-picker"
-        />
-      </div>
+    <div className="color-form--color-input-wrapper">
+      <input
+        id={id}
+        name={id}
+        type="text"
+        value={inputValue}
+        onChange={handleInputValue}
+        className="color-form--input-field--color-text"
+      />
+      <input
+        type="color"
+        value={inputValue}
+        onChange={handleInputValue}
+        className="color-form--input-field--color-picker"
+      />
+    </div>
   );
 }

--- a/src/Components/ColorInput/ColorInput.jsx
+++ b/src/Components/ColorInput/ColorInput.jsx
@@ -1,10 +1,11 @@
 import { useState } from "react";
 
-export default function ColorInput({ id, defaultValue }) {
+export default function ColorInput({ id, defaultValue, cardBackgroundColor }) {
   const [inputValue, setInputValue] = useState(defaultValue);
 
   const handleInputValue = (event) => {
     setInputValue(event.target.value);
+    cardBackgroundColor(event.target.value);
   };
 
   return (

--- a/src/Components/ColorInput/ColorInput.jsx
+++ b/src/Components/ColorInput/ColorInput.jsx
@@ -1,11 +1,18 @@
 import { useState } from "react";
 
-export default function ColorInput({ id, defaultValue, cardBackgroundColor }) {
+export default function ColorInput({
+  id,
+  defaultValue,
+  cardBackgroundColor,
+  cardContrastTextColor,
+}) {
   const [inputValue, setInputValue] = useState(defaultValue);
 
   const handleInputValue = (event) => {
     setInputValue(event.target.value);
-    cardBackgroundColor(event.target.value);
+    id === "hex"
+      ? cardBackgroundColor(event.target.value)
+      : cardContrastTextColor(event.target.value);
   };
 
   return (


### PR DESCRIPTION
https://github.com/StephMode/iro/issues/37

This PR is about the work to refactor existing components to prepare for the design overhaul.

To achieve this, I did the following:
- streamline and simplify both the jsx in the `ColorForm` component and its `.css` for cleaner code and less dom nesting.
- improve styling of the form and components of the form.
- style the `ColorForm` so that it better blends in in `editMode`.
- develop logic for the `ColorForm` reflect to directly reflect input values on `hex` and `contrastText`
